### PR TITLE
Allow to use the same name for exceptions with different parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.1 (Jan 7, 2023)
+
+-   Exceptions with different parent now can have the same name.
+-   All exceptions inherit BaseException.
+-   BaseException's name is Exception.
+
 # v1.0.0 (Oct 10, 2022)
 
 -   Make it simple by removing Generator.

--- a/default.go
+++ b/default.go
@@ -22,13 +22,13 @@ package xyerror
 
 // Predefined Exceptions.
 var (
-	BaseException      = NewException("BaseException")
-	IOError            = NewException("IOError")
-	FloatingPointError = NewException("FloatingPointError")
-	IndexError         = NewException("IndexError")
-	KeyError           = NewException("KeyError")
-	ValueError         = NewException("ValueError")
-	ParameterError     = NewException("ParameterError")
-	TypeError          = NewException("TypeError")
-	AssertionError     = NewException("AssertionError")
+	BaseException      = Exception{name: "Exception"}
+	IOError            = BaseException.NewException("IOError")
+	FloatingPointError = BaseException.NewException("FloatingPointError")
+	IndexError         = BaseException.NewException("IndexError")
+	KeyError           = BaseException.NewException("KeyError")
+	ValueError         = BaseException.NewException("ValueError")
+	ParameterError     = BaseException.NewException("ParameterError")
+	TypeError          = BaseException.NewException("TypeError")
+	AssertionError     = BaseException.NewException("AssertionError")
 )


### PR DESCRIPTION
#### Issue

-   Allow to use the same name for exceptions with different parent.

#### Changes

-   [ ] Fix bug
-   [x] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Checked README.md.
-   [x] Checked CHANGELOG.md
-   [x] Checked comments.
